### PR TITLE
Base64 image input

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ python3 inference.py \
 </code>
 </details>
 
+## Serving
+
+See [Tensorflow Serving example](deployments/tensorflow-serving/README.md)
+
 ## Additional Training
 
 You can finetune the model yourself on your own data, to do so is fairly simple - though you will need the checkpoint files as can be found in `saved_checkpoint/` in `private_detector.zip`

--- a/deployments/tensorflow-serving/README.md
+++ b/deployments/tensorflow-serving/README.md
@@ -3,13 +3,13 @@
 Tensorflow serving image could be pulled via:
 
 ```shell
-docker pull <image_name>
+docker pull vazhega/private-detector:0.2.0
 ```
 
 Run: 
 
 ```shell
-docker run -p 8501:8501 -e MODEL_NAME=private_detector -t <image_name>
+docker run -p 8501:8501 -e MODEL_NAME=private_detector -t vazhega/private-detector:0.2.0
 ```
 
 Ports exposed:

--- a/deployments/tensorflow-serving/README.md
+++ b/deployments/tensorflow-serving/README.md
@@ -1,0 +1,35 @@
+## Private Detector on Tensorflow Serving
+
+Tensorflow serving image could be pulled via:
+
+```shell
+docker pull <image_name>
+```
+
+Run: 
+
+```shell
+docker run -p 8501:8501 -e MODEL_NAME=private_detector -t <image_name>
+```
+
+Ports exposed:
+* REST API: **8501**
+* GRPC: **8502**
+
+Calling a model:
+
+```python
+import base64
+import json
+import requests
+
+image_string = open("./test.jpeg", "rb").read()
+endpoint = "http://localhost:8501/v1/models/private_detector:predict"
+jpeg_bytes = base64.b64encode(image_string).decode('utf-8')
+predict_request = {"instances" : [{"b64": jpeg_bytes}]}
+
+response = requests.post(endpoint, json.dumps(predict_request))
+print(response.json())
+
+>>> {'predictions': [[0.0535223149, 0.946477652]]}
+```

--- a/private_detector/private_detector.py
+++ b/private_detector/private_detector.py
@@ -12,7 +12,7 @@ from .utils import loss
 from .utils.efficientnet_config import EfficientNetV2Config
 from .utils.effnetv2_model import EffNetV2Model
 from .utils.tensorboard_callback import Callback
-from .utils.preprocess import pad_resize_image, preprocess_for_evaluation
+from .utils.preprocess import preprocess_for_evaluation
 
 
 class PrivateDetector():

--- a/train.py
+++ b/train.py
@@ -214,6 +214,7 @@ def train(train_id: str,
     logger.info(f'Training complete, saving model to {train_id}')
 
     model.save(train_id)
+    model.save_base64_serving(train_id, input_dtype=dtype)
 
     logger.info(f'Model saved to {train_id}')
 


### PR DESCRIPTION
Adding functionality mentioned in https://github.com/bumble-tech/private-detector/issues/11

Added a function `save_base64_serving` that adds:

- base64 input layer
- preprocessing layer
- softmax layer as the output

I've also added a sample client example in `README.md` 

